### PR TITLE
Gardens

### DIFF
--- a/src/components/ActivityGraph.astro
+++ b/src/components/ActivityGraph.astro
@@ -56,18 +56,18 @@ const multiplier = (16 * 4) / highest;
             <span class="hidden()">{articlesLabel}</span>
           </span>
           <span
-            class="gardens"
-            style={{ height: gardens * multiplier + "px" }}
-            title={gardensLabel}
-          >
-            <span class="hidden()">{gardensLabel}</span>
-          </span>
-          <span
             class="notes"
             style={{ height: notes * multiplier + "px" }}
             title={notesLabel}
           >
             <span class="hidden()">{notesLabel}</span>
+          </span>
+          <span
+            class="gardens"
+            style={{ height: gardens * multiplier + "px" }}
+            title={gardensLabel}
+          >
+            <span class="hidden()">{gardensLabel}</span>
           </span>
           <span
             class="rss-club"
@@ -100,13 +100,13 @@ const multiplier = (16 * 4) / highest;
     font-size: small;
   }
   li span.articles {
-    background: var(--primary);
+    background: var(--purple);
   }
   li span.gardens {
-    background: var(--github-dark-green);
+    background: var(--green);
   }
   li span.notes {
-    background: var(--accent);
+    background: var(--blue);
   }
   li span.rss-club {
     background: var(--off-background);

--- a/src/components/ActivityGraph.astro
+++ b/src/components/ActivityGraph.astro
@@ -1,19 +1,27 @@
 ---
-import { getArticles, getNotes } from "src/utils";
+import { getArticles, getGardens, getNotes } from "src/utils";
 
 const articles = await getArticles();
+const gardens = await getGardens();
 const notes = await getNotes();
 
 const yearCount: Record<
   number,
-  { articles: number; notes: number; rssClub: number }
+  { articles: number; gardens: number; notes: number; rssClub: number }
 > = {};
 
-[...articles, ...notes].forEach((content) => {
-  const year = new Date(content.data.pubDate).getFullYear();
-  if (!yearCount[year]) yearCount[year] = { articles: 0, notes: 0, rssClub: 0 };
+[...articles, ...gardens, ...notes].forEach((content) => {
+  const year = new Date(
+    content.data.hasOwnProperty("tendedDates")
+      ? content.data.tendedDates.slice(-1)
+      : content.data.pubDate
+  ).getFullYear();
+  if (!yearCount[year]) yearCount[year] = { articles: 0, gardens: 0, notes: 0, rssClub: 0 };
   if (content.collection === "notes") {
     yearCount[year].notes++;
+  }
+  if (content.collection === "gardens") {
+    yearCount[year].gardens++;
   }
   if (content.collection === "articles") {
     if (content.data.flags?.includes("RSS-ONLY")) {
@@ -25,15 +33,16 @@ const yearCount: Record<
 });
 
 const highest = Math.max(
-  ...Object.values(yearCount).map((record) => record.articles + record.notes)
+  ...Object.values(yearCount).map((record) => record.articles + record.gardens + record.notes + record.rssClub)
 );
 const multiplier = (16 * 4) / highest;
 ---
 
 <ol>
   {
-    Object.entries(yearCount).map(([year, { articles, notes, rssClub }]) => {
+    Object.entries(yearCount).map(([year, { articles, gardens, notes, rssClub }]) => {
       const articlesLabel = `${articles} articles`;
+      const gardensLabel = `${gardens} gardens`;
       const notesLabel = `${notes} notes`;
       const rssClubLabel = `${rssClub} RSS Club articles`;
       return (
@@ -45,6 +54,13 @@ const multiplier = (16 * 4) / highest;
             title={articlesLabel}
           >
             <span class="hidden()">{articlesLabel}</span>
+          </span>
+          <span
+            class="gardens"
+            style={{ height: gardens * multiplier + "px" }}
+            title={gardensLabel}
+          >
+            <span class="hidden()">{gardensLabel}</span>
           </span>
           <span
             class="notes"
@@ -85,6 +101,9 @@ const multiplier = (16 * 4) / highest;
   }
   li span.articles {
     background: var(--primary);
+  }
+  li span.gardens {
+    background: var(--github-dark-green);
   }
   li span.notes {
     background: var(--accent);

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,14 +1,14 @@
 ---
 const { pathname } = Astro.url;
 
-const crumbs = [];
+const crumbs = ["/"];
 
 for (let i = 0; i < pathname.length; i++) {
   const character = pathname[i];
   if (character === "/") {
     const crumb = pathname.slice(0, i);
     if (crumb) {
-        crumbs.push(crumb);
+      crumbs.push(crumb);
     }
   }
 }
@@ -28,12 +28,39 @@ function crumbToLabel(crumb) {
 {
   crumbs.length > 0 && (
     <nav aria-label="breadcrumbs" class="line()">
-      {crumbs.map((crumb, i) => (
-        <>
-          {i > 0 && <span class="divider()" />}
-          <a href={crumb}>{crumbToLabel(crumb)}</a>
-        </>
-      ))}
+      {crumbs.map((crumb, i) =>
+        i === 0 ? (
+          <a href={crumb} class="center()">
+            <svg
+              aria-label={crumbToLabel(crumb)}
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 256 256"
+            >
+              <rect width="256" height="256" fill="none" />
+              <path
+                d="M152,208V160a8,8,0,0,0-8-8H112a8,8,0,0,0-8,8v48a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V115.54a8,8,0,0,1,2.62-5.92l80-75.54a8,8,0,0,1,10.77,0l80,75.54a8,8,0,0,1,2.62,5.92V208a8,8,0,0,1-8,8H160A8,8,0,0,1,152,208Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+            </svg>
+          </a>
+        ) : (
+          <>
+            {i > 0 && <span class="divider()" />}
+            <a href={crumb}>{crumbToLabel(crumb)}</a>
+          </>
+        )
+      )}
     </nav>
   )
 }
+
+<style>
+  svg {
+    width: 1.5em;
+    height: 1.5em;
+  }
+</style>

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -5,11 +5,13 @@ import {
   getTags,
   getArticleTitle,
   slugify,
+getGardens,
 } from "src/utils";
 import socials from "src/data/socials";
 import navigation from "src/data/navigation";
 
 const articles = await getArticles({ excludeRSSOnlyInProd: true });
+const gardens = await getGardens();
 const notes = await getNotes();
 const tags = getTags(articles);
 
@@ -19,6 +21,12 @@ const options = [
     url: `/articles/${article.slug}`,
     label: getArticleTitle(article.data),
     searchable: (article.data.title + article.data.description).toLowerCase(),
+  })),
+  ...gardens.map(garden => ({
+    type: "Garden",
+    url: `/gardens/${garden.slug}`,
+    label: garden.data.title,
+    searchable: (garden.data.title + garden.data.description).toLowerCase(),
   })),
   ...notes.map((note) => ({
     type: "Note",

--- a/src/components/ContentFooter.astro
+++ b/src/components/ContentFooter.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+  title: string;
+  verse?: string;
+}
+
+const verse = Astro.props.verse ?? "Romans 5:8";
+---
+
+<footer class="line()">
+  <a
+    href={`mailto:sean@seanmcp.com?subject=Re: ${Astro.props.title}`}
+    id="comment-link">Reply by email</a
+  >
+  <bible-verse>{verse}</bible-verse>
+</footer>
+
+<style>
+  bible-verse {
+    margin-inline-start: auto;
+  }
+
+  :global(bible-verse div) {
+    background-color: var(--background);
+    border: var(--stroke-thickness) solid var(--off-background);
+    bottom: calc(100% + var(--space-xs));
+    padding: var(--space-xs);
+    right: calc(-1 * var(--space-xs));
+    width: 30ch;
+  }
+</style>

--- a/src/components/Feed.astro
+++ b/src/components/Feed.astro
@@ -206,6 +206,19 @@ feed = feed.slice(0, count);
     --size: 1.5em;
     height: var(--size);
     min-width: var(--size);
+    transition: all 0.1s ease-in-out;
     width: var(--size);
+  }
+
+  article:is(:focus-within, :hover) svg[aria-label="article"] {
+    color: var(--purple);
+  }
+
+  article:is(:focus-within, :hover) svg[aria-label="garden"] {
+    color: var(--green);
+  }
+
+  article:is(:focus-within, :hover) svg[aria-label="note"] {
+    color: var(--blue);
   }
 </style>

--- a/src/components/Feed.astro
+++ b/src/components/Feed.astro
@@ -1,0 +1,211 @@
+---
+import { getArticles, getGardens, getNotes } from "src/utils";
+import ReadableTime from "./ReadableTime.astro";
+
+interface Props {
+  count?: number;
+}
+
+const {count} = Astro.props
+
+const articles = await getArticles({ count });
+const gardens = await getGardens();
+const notes = await getNotes(count);
+
+let feed = [].concat(articles, gardens, notes);
+
+feed.sort((a, b) => {
+  const aDate = a.data.tendedDates ? a.data.tendedDates[0] : a.data.pubDate;
+  const bDate = b.data.tendedDates ? b.data.tendedDates[0] : b.data.pubDate;
+
+  return aDate > bDate ? -1 : 1;
+});
+
+feed = feed.slice(0, count);
+---
+
+<section class="stack()">
+  {
+    feed.map((item) => {
+      const title = item.data.title || `Note #${item.slug}`;
+      let svg;
+      switch (item.collection) {
+        case "articles":
+          svg = (
+            <>
+              <rect
+                x="32"
+                y="48"
+                width="192"
+                height="160"
+                rx="8"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <line
+                x1="80"
+                y1="96"
+                x2="176"
+                y2="96"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <line
+                x1="80"
+                y1="128"
+                x2="176"
+                y2="128"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <>
+                <rect width="256" height="256" fill="none" />
+                <line
+                  x1="80"
+                  y1="160"
+                  x2="176"
+                  y2="160"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="16"
+                />
+              </>
+            </>
+          );
+          break;
+        case "gardens":
+          svg = (
+            <>
+              <path
+                d="M144.28,111.72c-25.08-41.81,8.36-83.61,79.43-79.43C227.89,103.36,186.09,136.8,144.28,111.72Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <path
+                d="M98,114c18.24-30.41-6.08-60.81-57.77-57.77C37.17,107.9,67.57,132.22,98,114Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <line
+                x1="56"
+                y1="152"
+                x2="200"
+                y2="152"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <path
+                d="M184,152l-14.61,65.74a8,8,0,0,1-7.81,6.26H94.42a8,8,0,0,1-7.81-6.26L72,152"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <line
+                x1="144.28"
+                y1="111.72"
+                x2="104"
+                y2="152"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <rect width="256" height="256" fill="none" />
+              <line
+                x1="97.98"
+                y1="113.98"
+                x2="120"
+                y2="136"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+            </>
+          );
+          break;
+        case "notes":
+          svg = (
+            <>
+              <path
+                d="M156.69,216H48a8,8,0,0,1-8-8V48a8,8,0,0,1,8-8H208a8,8,0,0,1,8,8V156.69a8,8,0,0,1-2.34,5.65l-51.32,51.32A8,8,0,0,1,156.69,216Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <rect width="256" height="256" fill="none" />
+              <polyline
+                points="215.28 159.99 160 159.99 160 215.27"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+            </>
+          );
+          break;
+      }
+      return (
+        <article class="line()">
+          <svg
+            aria-label={item.collection.slice(0, item.collection.length - 1)}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 256 256"
+          >
+            {svg}
+          </svg>
+
+          <span>
+            <a href={`/${item.collection}/${item.slug}`}>{title}</a>
+            <ReadableTime
+              date={
+                item.data.tendedDates
+                  ? item.data.tendedDates[0]
+                  : item.data.pubDate
+              }
+            />
+          </span>
+        </article>
+      );
+    })
+  }
+</section>
+
+<style>
+  a {
+    font-weight: bold;
+  }
+  svg {
+    --size: 1.5em;
+    height: var(--size);
+    min-width: var(--size);
+    width: var(--size);
+  }
+</style>

--- a/src/components/GardenDetails.astro
+++ b/src/components/GardenDetails.astro
@@ -7,18 +7,18 @@ interface Props {
 
 const {tendedDates} = Astro.props
 const count = tendedDates.length
-let message = `Tended ${count} times`
+let tendedCount = `Tended ${count} times`
 if (count === 1) {
-    message = "Tended once"
+    tendedCount = "Tended once"
 } else if (count === 2) {
-    message = `Tended twice`
+    tendedCount = `Tended twice`
 }
 ---
 
-<small class="line(xs)">
-    <span>Planted {readableDate(tendedDates[tendedDates.length - 1])}</span>
-    <span class="divider()" />
-    <span>{message}</span>
-    <span class="divider()" />
+<div class="line(xs)">
     <span>Last tended {readableDate(tendedDates[0])}</span>
-</small>
+    <span class="divider()" />
+    <span>{tendedCount}</span>
+    <span class="divider()" />
+    <span>Planted {readableDate(tendedDates[tendedDates.length - 1])}</span>
+</div>

--- a/src/components/GardenDetails.astro
+++ b/src/components/GardenDetails.astro
@@ -1,0 +1,24 @@
+---
+import { readableDate } from 'src/utils';
+
+interface Props {
+    tendedDates: Date[];
+}
+
+const {tendedDates} = Astro.props
+const count = tendedDates.length
+let message = `Tended ${count} times`
+if (count === 1) {
+    message = "Tended once"
+} else if (count === 2) {
+    message = `Tended twice`
+}
+---
+
+<small class="line(xs)">
+    <span>Planted {readableDate(tendedDates[tendedDates.length - 1])}</span>
+    <span class="divider()" />
+    <span>{message}</span>
+    <span class="divider()" />
+    <span>Last tended {readableDate(tendedDates[0])}</span>
+</small>

--- a/src/components/GardenTitle.astro
+++ b/src/components/GardenTitle.astro
@@ -1,0 +1,100 @@
+---
+interface Props {
+    state: "FRESH" | "WILD";
+    title: string;
+}
+---
+
+<span class="line(xs)">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+    <rect width="256" height="256" fill="none"></rect>
+      {Astro.props.state === "FRESH" && (
+        <path
+        d="M144.28,111.72c-25.08-41.81,8.36-83.61,79.43-79.43C227.89,103.36,186.09,136.8,144.28,111.72Z"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path><path
+        d="M98,114c18.24-30.41-6.08-60.81-57.77-57.77C37.17,107.9,67.57,132.22,98,114Z"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path><line
+        x1="56"
+        y1="152"
+        x2="200"
+        y2="152"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></line><path
+        d="M184,152l-14.61,65.74a8,8,0,0,1-7.81,6.26H94.42a8,8,0,0,1-7.81-6.26L72,152"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path><line
+        x1="144.28"
+        y1="111.72"
+        x2="104"
+        y2="152"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></line><line
+        x1="97.98"
+        y1="113.98"
+        x2="120"
+        y2="136"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></line>
+      )}
+      {Astro.props.state === "WILD" && (
+        <path
+        d="M138.54,141.46C106.62,88.25,149.18,35.05,239.63,40.37,245,130.82,191.75,173.38,138.54,141.46Z"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path><path
+        d="M88.47,152.47c22.8-38-7.6-76-72.21-72.21C12.46,144.87,50.47,175.27,88.47,152.47Z"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path><line
+        x1="56"
+        y1="120"
+        x2="120"
+        y2="184"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></line><path
+        d="M200,80l-61.25,61.25A64,64,0,0,0,120,186.51V216"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"></path>
+      )}
+      </svg
+    >
+    {Astro.props.title}
+</span>
+
+<style>
+    svg {
+        height: 1em;
+        min-width: 1em;
+        width: 1em;
+    }
+</style>

--- a/src/content/articles/covid-19-journal.md
+++ b/src/content/articles/covid-19-journal.md
@@ -3,7 +3,6 @@ title: COVID-19 journal
 description: Recording my experience contracting COVID-19 in 2020
 pubDate: 2021-03-24
 tags:
-    - Garden
     - Personal
 verse: Psalm 103:3
 image: /img/surgical-mask.min.jpg

--- a/src/content/articles/solid-vs-code-extensions.md
+++ b/src/content/articles/solid-vs-code-extensions.md
@@ -3,7 +3,6 @@ title: Solid VS Code extensions
 description: A curated list of great extensions that might fly under your radar
 pubDate: 2022-09-06T14:18:37.349Z
 tags:
-  - Garden
   - VS Code
 ---
 I [use](/uses) VS Code as my daily editor, and one of its best features is the wide selection of extensions. However, as with any other large marketplace, discoverability is a real issue.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -15,6 +15,14 @@ const articles = defineCollection({
   }),
 });
 
+const gardens = defineCollection({
+  schema: z.object({
+    description: z.string(),
+    title: z.string(),
+    tendedDates: z.array(z.date())
+  }),
+});
+
 const notes = defineCollection({
   schema: z.object({
     edited: z.boolean().optional(),
@@ -24,5 +32,6 @@ const notes = defineCollection({
 
 export const collections = {
   articles,
+  gardens,
   notes,
 };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -18,6 +18,7 @@ const articles = defineCollection({
 const gardens = defineCollection({
   schema: z.object({
     description: z.string(),
+    head: z.string().optional(),
     title: z.string(),
     tendedDates: z.array(z.date())
   }),

--- a/src/content/gardens/before-debugging.md
+++ b/src/content/gardens/before-debugging.md
@@ -1,0 +1,54 @@
+---
+title: Before Debugging
+description: An organized approach to debugging your code
+tendedDates:
+  - 2020-07-10
+verse: Proverbs 30:25
+---
+
+Debugging, "the process of finding and resolving defects within a computer
+system"[^1], is a critical skill for software development. It's how we figure
+out what went wrong and how to fix it.
+
+This can be as informal as throwing `* { outline: 1px solid red }` on all your
+elements or sophisticated as using an IDE's debugger.
+
+But whatever your method, there are certain steps that you can follow to help
+yourself debug more logically and efficiently.
+
+This garden aims to detail everything you should do _before you actually start
+debugging_. Think of this as the prep work before you start cooking.
+
+## Pre-steps
+
+1. **Relax**: Find a bug can be frustrating, and those emotions can impede the
+   debugging process. Take a deep breath and dive in.
+1. **Describe what happened**: Did the process exit? Did the page fail to
+   render? Is there a message in the console? Does the UI not respond correctly?
+   Understanding what happened is the first step to solving a problem. The "how"
+   comes later.
+1. **Read the error message**: Most errors will provide you useful information
+   in the message. Some APIs provide a detailed explanation of what went wrong.
+   So take the time and read it.
+1. **Follow the stack trace**: If the error includes a stack, walk through each
+   line. Where did the error originate? What it internal or external code?
+1. **Pinpoint the error**: Try to isolate the exact point where something went
+   wrong. In the stack trace, this will usually have a file name and a line
+   number, _e.g._ `app.js:25`.
+1. **Inspect the line**: Read the entire line where the error occurred. Is there
+   anything that immediately jumps out to you? Sometimes the bug could be as
+   simple as a typo or an unexpected type.
+1. **Review the block**: Follow the block from start to finish, making note of
+   the line in question. Try to get a good sense of how that code is working.
+1. **Scan any higher scopes**: Make sure you understand at a high-level what the
+   code is doing and what variables are needed/expected.
+1. **Make a hypothesis**: You are a scientist, after all. Make an educated guess
+   about what went wrong and what will fix it. Make sure to review your
+   hypothesis while you're debugging.
+
+## Additional reading
+
+- [_When debugging, your attitude matters_](https://jvns.ca/blog/debugging-attitude-matters/)
+  by Julia Evans
+
+[^1]: https://en.wikipedia.org/wiki/Debugging

--- a/src/content/gardens/browser-extensions.md
+++ b/src/content/gardens/browser-extensions.md
@@ -1,0 +1,30 @@
+---
+title: Browser extensions
+description: A curated list of helpful browser extensions.
+tendedDates:
+  - 2022-10-31T13:11:45.434Z
+---
+
+Extensions can slow down your browser, so I try to only add ones that are
+necessary or super helpful. Here is a list of the extensions that make the cut,
+grouped by category and listed alphabetically:
+
+## General use
+
+- [Disable automatic gain control](https://chrome.google.com/webstore/detail/disable-automatic-gain-co/clpapnmmlmecieknddelobgikompchkk):
+  I've written
+  [an article about this extension already](/articles/prevent-chrome-from-adjusting-audio-input-levels-on-mac/);
+  it prevents Chrome from automatically adjusting the gain for your audio input.
+  I couldn't use Meet on Chrome without this extension!
+- [uBlock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm):
+  Simple and effective ad blocking. **Add this on every grandparent's
+  computer!**
+
+## Developers
+
+- [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd):
+  Adds an accessibility audit panel to the developer tools.
+- [Markdown Editor for GitHub](https://chrome.google.com/webstore/detail/monaco-markdown-editor-fo/mmpbdjdnmhgkpligeniippcgfmkgkpnf):
+  Converts GitHub's default `textarea` into a full-featured Monaco editor. This
+  means you can use your favorite VS-Code keyboard shortcuts when editing issue
+  descriptions and PR comments.

--- a/src/content/gardens/building-browser-extensions.md
+++ b/src/content/gardens/building-browser-extensions.md
@@ -1,0 +1,35 @@
+---
+title: Building browser extensions
+description: Some resources and guides for making browser add-ons/extensions
+tendedDates:
+  - 2021-02-23
+---
+
+These are resources that I reference and guides that I follow while developing
+browser add-ons/extensions. Hopefully this garden will be helpful to you along
+the way!
+
+## Resources
+
+- [How to install temporary add-ons in Firefox (MDN)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#installing)
+- [Icons for Chrome extensions (chrome.com)](https://developer.chrome.com/docs/extensions/mv2/manifest/icons/)
+- [`manifest.json` documentation (MDN)](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json)
+- [Sample build script (GitHub)](https://raw.githubusercontent.com/SeanMcP/popsicle-sticks-mini/master/build.sh)
+
+## Guides
+
+### How to add to browser while developing
+
+#### Chrome
+
+1. Go to [`chrome://extensions`](chrome://extensions)
+2. Enable "Developer mode"
+3. Select "Load unpacked"
+4. Select the project directory
+
+#### Firefox
+
+1. Go to
+   [`about:debugging#/runtime/this-firefox`](about:debugging#/runtime/this-firefox)
+2. Select "Load Temporary Add-on..."
+3. Select the project directory

--- a/src/content/gardens/coding-music.md
+++ b/src/content/gardens/coding-music.md
@@ -1,0 +1,29 @@
+---
+title: Coding Music
+description:
+  A growing list of artists that I like to listen to while programming.
+tendedDates:
+  - 2022-02-15
+verse: Psalm 150:3
+---
+
+Whenever I need to put my head down and focus on a coding task, I have found
+that listening to music can help me focus and increase my productivity.
+
+There are two main criteria that I have for music while I am programming: 1) it
+needs to be instrumental, and 2) it needs to have a decent beat/tempo. If a song
+can check both of those boxes, then it gets added to the rotation.
+
+Here is a list of songs/artists that I enjoy listening to while I work, in
+alphabetical order:
+
+- [Arcade High](https://music.youtube.com/channel/UCT7LeKzJCc5P1AKY1Ghxjiw)
+- [Com Truise](https://music.youtube.com/channel/UC3G1cV92stSGOy4cLgXmgJQ)
+- [Dynatron](https://music.youtube.com/channel/UCov2JBrKDko0xcwfIwhEAfw)
+- [Magic Sword](https://music.youtube.com/channel/UCnl2TnNDgp2rUepf5VnXJ1g)
+- [S U R V I V E](https://music.youtube.com/channel/UCec-IpmkXJQhgnkBIx1EGxQ)
+- [Timecop1983](https://music.youtube.com/channel/UCVjNyglpxEwPoB65b0Oc4Ew)
+- [Waveshaper](https://music.youtube.com/channel/UCzdwXtAUt8VgaDXfTfttx8A)
+
+As of writing, these artists are all in similar, but as the lists grows I plan
+on organizing things by genre.

--- a/src/content/gardens/coding-music.md
+++ b/src/content/gardens/coding-music.md
@@ -3,6 +3,7 @@ title: Coding Music
 description:
   A growing list of artists that I like to listen to while programming.
 tendedDates:
+  - 2023-05-23
   - 2022-02-15
 verse: Psalm 150:3
 ---
@@ -20,6 +21,7 @@ alphabetical order:
 - [Arcade High](https://music.youtube.com/channel/UCT7LeKzJCc5P1AKY1Ghxjiw)
 - [Com Truise](https://music.youtube.com/channel/UC3G1cV92stSGOy4cLgXmgJQ)
 - [Dynatron](https://music.youtube.com/channel/UCov2JBrKDko0xcwfIwhEAfw)
+- [Hotel Pools](https://music.youtube.com/channel/UCHNQ_4_csObrqJ9p7q-Xxgg)
 - [Magic Sword](https://music.youtube.com/channel/UCnl2TnNDgp2rUepf5VnXJ1g)
 - [S U R V I V E](https://music.youtube.com/channel/UCec-IpmkXJQhgnkBIx1EGxQ)
 - [Timecop1983](https://music.youtube.com/channel/UCVjNyglpxEwPoB65b0Oc4Ew)

--- a/src/content/gardens/git.md
+++ b/src/content/gardens/git.md
@@ -1,0 +1,70 @@
+---
+title: Git
+description: A garden all about Git
+tendedDates:
+  - 2021-05-04
+---
+
+Here are some of the git commands that I find useful when doing by work as a
+software engineer. Hopefully you will find them helpful too!
+
+## Commands
+
+### `git checkout -`
+
+Quick: Checkout the previous branch
+
+This is super handy when working with long or unwieldy branch names. With the
+`-` reference, you can convert the following set of commands into a reusable
+alias:
+
+```shell
+git checkout dev && git pull && git checkout - && git merge dev
+```
+
+### `git checkout -- .`
+
+Quick: Delete all changes in the current branch
+
+When you just want to start from scratch on the current branch, this command is
+a huge timesaver. The `--` refers to the current branch, while the `.` refers to
+all files. If you want to reset a particular file, you could swap the name with
+the `.`.
+
+### `git commit -m "init" --allow-empty`
+
+Quick: Create a commit with no changes
+
+When starting on a development task, sometimes it's nice to set up branches and
+PRs before getting started on the work. The `--allow-empty` flag enables you to
+create commits without changing any files.
+
+I use this when I have a feature branch that will be the target of bunch of
+smaller branches. Initializing a those with an empty commit helps be get
+organized in the beginning.
+
+### `git diff branch_name -S "TODO:"`
+
+Quick: Search the diff between the current branch and `branch_name` for all
+strings matching `TODO:`
+
+When working on a new feature, I like to leave myself todos to address before
+the branch is merged. Tracking these down can be tricky because there are other
+`TODO:`s in the codebase. I used to `grep` through the diff, but git's `-S` flag
+is much easier.
+
+### `git diff branch_name -G "/*-action"`
+
+Quick: Search the diff between the current branch and `branch_name` for all
+strings matching the `/*-action` RegEx pattern
+
+Similar to the `-S` flag, `-G` lets you search through the diff using RegEx. I
+don't know too much about regular expressions, but it's nice to have the option
+in your toolbelt.
+
+### `git log --before="2021-01-01 00:00"`
+
+Quick: Limit the log output to all commits before the provided date.
+
+This is handy when you want to look at commits from a particular date or before
+a date (and/or after with `--after=`).

--- a/src/content/gardens/jest.md
+++ b/src/content/gardens/jest.md
@@ -1,0 +1,100 @@
+---
+title: Jest
+description:
+  A growing list of little things that make working with Jest a little better
+tendedDates:
+  - 2022-10-06T15:58:09.243Z
+verse: Acts 17:11
+---
+
+Since 2017, I have only used Jest for JavaScript application testing. And while
+[Vitest does look exciting](https://vitest.dev/), I think that it's safe to say
+that Jest will be around for a good while longer.
+
+Here are some of tips and tricks that I've learned that make working with Jest a
+little better. The headings are organized alphabetically for ease of reference.
+
+## Aliases
+
+Jest's global `test` method has an `it` alias that you might find useful. There
+is usually a standard in the codebase where I'm working, but I've found that
+tests can read a little more naturally with the alias:
+
+```js
+test("When a user is logged in, ...", () => {});
+it("Logs an event on interaction", () => {});
+```
+
+## `expect`
+
+There are a lot of matcher functions that are good to know, so I'll only list a
+few here.
+
+One of the most useful matchers (and hardest to remember) is
+`expect.objectContaining()`. This allows you to assert that certain
+properties/values are present on the object without needing to mock all of them.
+
+```js
+expect(mockFn).toHaveBeenCalledWith(
+  expect.objectContaining({
+    example: true,
+  })
+);
+```
+
+Another handy matcher is `not()`, which gives you a simple way to negate any
+matcher:
+
+```js
+expect(sum).not.toBe(0);
+expect(typeof readableTime).not.toBe("number");
+```
+
+I do recommend skimming the
+[Jest docs for `expect`](https://jestjs.io/docs/expect) occasionally to pick up
+some new matcher that might help in your next test.
+
+## Flags
+
+The Jest CLI has a number of flags that can be used to change the way that Jest
+runs. Here are some of the ones that I find most helpful:
+
+- `--bail/-b`: Exits the test suite after a given number of failures (default 1)
+- `--changedSince`: Only run tests related to files changed since a given point.
+  I like to use this with the target branch as a quick check for regressions. -﻿
+  `--findRelatedTests`: Runs tests related to changed files. Works well in a
+  pre-commit hook.
+- `--watch`: Run tests in watch mode. Great when running a small set of tests,
+  but maybe omit if you're running the whole suite.
+
+## Selective runs
+
+When working in a large test file, it's nice to run only the cases that you care
+about. Sometimes that means selecting a specific test or block, and other times
+that means skipping anything that isn't necessary at the moment.
+
+To just run a specific test, you can use the `only()` method on the global
+`describe`/`test` methods. This will ensure that only that code is run:
+
+```js
+test.only("This test will run", () => {});
+test("This test will not", () => {});
+```
+
+To omit a test from the run, you can similarly use the `skip()` method:
+
+```js
+test("This test will run", () => {});
+test.skip("This test will not", () => {});
+```
+
+For a smaller change to skip tests, you can add an `x` to the front of for the
+same behavior:
+
+```js
+test("This test will run", () => {});
+xtest("This test will not", () => {});
+```
+
+If you're going to use this, I'd recommend
+[a linter rule to prevent you from committing skipped tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-disabled-tests.md).

--- a/src/content/gardens/latin.md
+++ b/src/content/gardens/latin.md
@@ -1,0 +1,22 @@
+---
+title: Latin
+description: This is a WIP that I may never finish.
+tendedDates:
+  - 2021-06-07
+---
+
+## Phrases
+
+### _ad hoc ergo propter hoc_
+
+"After that, because of that"
+
+### _ad nauseum_
+
+### _ceteris paribus_
+
+"All other things constant"
+
+### _et al_
+
+### _et cetera_

--- a/src/content/gardens/over-my-head.md
+++ b/src/content/gardens/over-my-head.md
@@ -1,0 +1,25 @@
+---
+title: Over my head
+description:
+  A list of articles, topics, and resources that are currently over my head
+tendedDates:
+  - 2020-04-24
+verse: Psalm 3:3
+---
+
+I am not as talented as I wish to be. As a result, I come across things on the
+web that are beyond my current level. This page is a garden for those topics.
+
+It is my goal to return to this page and move things from "are" over my head to
+"were."
+
+## Are
+
+- [_Profiling React.js Performance_](https://addyosmani.com/blog/profiling-react-js/)
+  by Addy Osmani
+- [_IndieWeb Link Sharing_](https://mxb.dev/blog/indieweb-link-sharing/) by Max
+  Böck
+
+## Were
+
+_None yet_

--- a/src/content/gardens/programming-reads.md
+++ b/src/content/gardens/programming-reads.md
@@ -1,0 +1,30 @@
+---
+title: Programming reads
+description: A list of articles, books, and resources for software engineers
+tendedDates:
+  - 2020-03-20
+verse: Nehemiah 8:8
+---
+
+This is an alphabetical list that has helped shape the way that I think about
+software engineering.
+
+At some point in the future I may add some commentary on why I found these
+insightful. Until then, you'll have to form those opinions for yourself.
+
+## Articles
+
+- [_Give it five minutes_](https://signalvnoise.com/posts/3124-give-it-five-minutes)
+  by Jason Fried
+
+- [_Optimize for change_](https://overreacted.io/optimized-for-change/) by Dan
+  Abramov
+
+- [_The wrong abstraction_](https://www.sandimetz.com/blog/2016/1/20/the-wrong-abstraction)
+  by Sandi Metz
+
+- [_Write code. Not too much. Mostly functions._](https://www.brandonsmith.ninja/blog/write-code-not-too-much-mostly-functions)
+  by Brandon Smith
+
+- [_Write code that is easy to delete, not easy to extend._](https://programmingisterrible.com/post/139222674273/write-code-that-is-easy-to-delete-not-easy-to)
+  by tef

--- a/src/content/gardens/react-native.md
+++ b/src/content/gardens/react-native.md
@@ -1,0 +1,87 @@
+---
+title: React Native
+description:
+  A growing list of terms you need to recognize when working in React Native
+tendedDates:
+  - 2021-10-07
+verse: Psalm 19:14
+---
+
+Building applications with React Native requires a high-level understanding of
+mobile development on Android and iOS devices in addition to React and React
+Native fundamentals. This glossary of terms will serve as a helpful reference
+when working across these environments.
+
+---
+
+<!--
+TERMS TO ADD:
+- JDK
+- JRE
+-->
+
+## AAB
+
+Android App Bundles (AABs) are a new format for publishing applications on
+Android. AABs can contain multiple APKs. Since August 2021, Google Play requires
+AABs for new apps.
+
+- [About Android App Bundles (Android)](https://developer.android.com/guide/app-bundle)
+
+## APK
+
+Android Package Kits (APKs) are an older format for publishing applications on
+Android.
+
+## `build.gradle`
+
+A `build.gradle` file contains all of the information for Gradle to compile
+Android apps, including dependency resolutions and tasks to process the source.
+
+- [_What is a `build.gradle` file?_](../what-is-a-build-gradle-file)
+
+## Gradle
+
+Gradle is an automated build tool that is used to compile Android apps from
+source code. It is configured in `build.gradle` files and run through a wrapper:
+`gradlew`/`gradlew.bat`.
+
+- [Gradle Build Tool](https://gradle.org/)
+- [Gradle tutorial for complete beginners (YouTube)](https://www.youtube.com/watch?v=-dtcEMLNmn0)
+
+## Hermes
+
+Hermes is a mobile-optimized JavaScript engine that is included in React Native
+builds for Android and iOS.
+
+- [Using Hermes (React Native)](https://reactnative.dev/docs/hermes)
+- [What is Hermes in React Native?](/articles/what-is-hermes-react-native/)
+
+## `Info.plist`
+
+The information property list or `Info.plist` is an XML file that contains all
+of the configuration data for your application. You can update these values
+directly or through the Xcode UI.
+
+- [About Info.plist Keys and Values (Apple)](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html)
+
+## JavaScriptCore/JSCore
+
+JavaScript Core or JSCore is a JavaScript engine that is included on iOS
+devices. It was included in Android builds to run JS code by React Native
+versions prior to `0.60`. It has since been replaced with [Hermes](#hermes).
+
+- [JavaScriptCore (Apple)](https://developer.apple.com/documentation/javascriptcore)
+
+<!--
+## JRE
+
+A Java Runtime Environment (JRE) is the code required to run a Java application. It contains all of the libraries and software that Java programs, and starts the Java Virtual Machine (JVM).
+
+- [Java Runtime Environment (IBM)](https://www.ibm.com/cloud/learn/jre)
+-->
+
+## SDK
+
+Software Development Kits (SDKs) are bundles of code to add to your application.
+Third parties will often have an SDK to integrate with their service.

--- a/src/content/gardens/slack-emojis.md
+++ b/src/content/gardens/slack-emojis.md
@@ -1,0 +1,52 @@
+---
+title: Slack Emojis
+description:
+  A curated list of the best reaction emojis that I have created for Slack
+tendedDates:
+  - 2022-01-04
+head: >-
+  <style>
+      table img {
+          width: 32px
+      }
+  </style>
+---
+
+I like reaction emojis and have spent an embarrassing amount of time
+[making new ones for myself and my coworkers](/articles/tools-for-custom-slack-emojis).
+These are some of my creations that were popular or just my favorites:
+
+| Image                                                            | Name                             |
+| ---------------------------------------------------------------- | -------------------------------- |
+| ![ack](/img/emojis/ack.jpg)                                      | `:ack:`                          |
+| ![all in this together](/img/emojis/all-in-this-together.gif)    | `:all-in-this-together:`         |
+| ![all seeing eye](/img/emojis/all-seeing-eye.jpg)                | `:all-seeing-eye:`               |
+| ![avalanche](/img/emojis/avalanche.png)                          | `:avalanche:`                    |
+| ![awe](/img/emojis/awe.gif)                                      | `:awe:`                          |
+| ![do it](/img/emojis/do-it.gif)                                  | `:do-it:`                        |
+| ![does not equal](/img/emojis/does-not-equal.png)                | `:does-not-equal:`/`:dne:`       |
+| ![eagle eye](/img/emojis/eagle-eye.jpg)                          | `:eagle-eye:`                    |
+| ![frankenstein's monster](/img/emojis/frankensteins-monster.jpg) | `:frankensteins-monster:`        |
+| ![good point](/img/emojis/good-point.png)                        | `:good-point:`                   |
+| ![good question](/img/emojis/good-question.png)                  | `:good-question:`                |
+| ![interesting](/img/emojis/interesting.gif)                      | `:interesting:`                  |
+| ![it's alive](/img/emojis/its-alive.jpg)                         | `:its-alive:`/`:frankenstein:`   |
+| ![nail biter](/img/emojis/nail-biter.gif)                        | `:nail-biter:`                   |
+| ![nerves](/img/emojis/nerves.gif)                                | `:nerves:`                       |
+| ![nice catch](/img/emojis/nice-catch.png)                        | `:nice-catch:`                   |
+| ![not crying](/img/emojis/not-crying.png)                        | `:not-crying:`                   |
+| ![ope](/img/emojis/ope.png)                                      | `:ope:`                          |
+| ![save your money](/img/emojis/save-your-money.png)              | `:save-your-money:`              |
+| ![shakes head](/img/emojis/shakes-head.gif)                      | `:shakes-head:`                  |
+| ![shivers](/img/emojis/shivers.gif)                              | `:shivers:`                      |
+| ![so close](/img/emojis/so-close.jpg)                            | `:so-close:`                     |
+| ![team](/img/emojis/team.gif)                                    | `:team:`                         |
+| ![this](/img/emojis/this.png)                                    | `:this:`                         |
+| ![this week i learned](/img/emojis/this-week-i-learned.png)      | `:this-week-i-learned:`/`:twil:` |
+| ![thumbs down](/img/emojis/thumbs-down.gif)                      | `:thumbs-down:`                  |
+| ![too big](/img/emojis/too-big.jpg)                              | `:too-big:`                      |
+| ![very interesting](/img/emojis/very-interesting.gif)            | `:very-interesting:`             |
+| ![yuck](/img/emojis/yuck.gif)                                    | `:yuck:`                         |
+| ![yikes](/img/emojis/yikes.png)                                  | `:yikes:`                        |
+
+Feel free to take inspiration or add to your workspace.

--- a/src/content/gardens/vs-code.md
+++ b/src/content/gardens/vs-code.md
@@ -1,0 +1,26 @@
+---
+title: VS Code
+description: A garden all about VS Code
+tendedDates:
+    - 2023-05-22T12:00:00.000Z
+    - 2023-01-04T19:51:08.581Z
+---
+
+VS Code is a great all-around editor.
+
+## Commands
+
+- **Fold All** collapses all code blocks for the current file. Very handy when you are exploring a new file that is super long.
+
+## Extensions
+
+- Code Spell Checker
+- Git Blame
+- GitHub Pull Requests and Issues
+- Live Server
+- Prettier
+- Search node_modules/
+
+## Settings
+
+- **Format on save**: `editor.formatOnSave`

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -4,35 +4,20 @@ const LINKS = {
     label: "Abby",
     url: "/abby/",
   },
+  about: {
+    description: "Learn more about me and my work",
+    label: "About",
+    url: "/about/",
+  },
   articles: {
     description: "Read articles about programming",
     label: "Articles",
     url: "/articles/",
   },
-  notes: {
-    description: "A feed of short notes, thoughts, or ideas",
-    label: "Notes",
-    url: "/notes/",
-  },
-  tags: {
-    description: "All of the tags for my articles",
-    label: "Tags",
-    url: "/tags/",
-  },
-  talks: {
-    description: "Outlines of talks I've given and workshops I've lead",
-    label: "Talks",
-    url: "/talks/",
-  },
   boardGames: {
     description: "My favorite board games",
     label: "Board Games",
     url: "/board-games/",
-  },
-  about: {
-    description: "Learn more about me and my work",
-    label: "About",
-    url: "/about/",
   },
   faith: {
     description: "A personal statement of faith",
@@ -44,6 +29,11 @@ const LINKS = {
     label: "Feed",
     url: "/rss.xml",
   },
+  gardens: {
+    description: "Evergreen resources that grow over time",
+    label: "Gardens",
+    url: "/gardens",
+  },
   map: {
     description: "A detailed site map",
     label: "Map",
@@ -53,6 +43,11 @@ const LINKS = {
     description: "A personal mission statement",
     label: "Mission",
     url: "/mission",
+  },
+  notes: {
+    description: "A feed of short notes, thoughts, or ideas",
+    label: "Notes",
+    url: "/notes/",
   },
   randomAricle: {
     description: "Navigate to a random article from my blog",
@@ -68,6 +63,16 @@ const LINKS = {
     description: "About my love of soccer and my favorite teams",
     label: "Soccer",
     url: "/soccer/",
+  },
+  tags: {
+    description: "All of the tags for my articles",
+    label: "Tags",
+    url: "/tags/",
+  },
+  talks: {
+    description: "Outlines of talks I've given and workshops I've lead",
+    label: "Talks",
+    url: "/talks/",
   },
   tools: {
     description:

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -34,8 +34,16 @@ const verse = data.verse ?? "Romans 5:8";
     <HeroImage image={data.image} />
     <ArticleSeries series={data.series} />
     {
+      data.tags?.includes("Garden") && (
+        <section class="attn">
+          Evergreen articles like this have moved:{" "}
+          <a href="/gardens">view my gardens section</a> 🌱
+        </section>
+      )
+    }
+    {
       data.flags?.includes("RSS-ONLY") && (
-        <section id="rss">
+        <section class="attn">
           This is a special article for <strong>the RSS Club</strong>, but feel
           free to save or share this link. You can join by subscribing to{" "}
           <a href="/rss.xml">my RSS feed</a>.
@@ -59,7 +67,7 @@ const verse = data.verse ?? "Romans 5:8";
     margin-block-end: var(--space-l) !important;
   }
 
-  #rss {
+  .attn {
     border: var(--stroke-thickness) solid var(--off-background);
     padding: var(--space-s);
   }

--- a/src/pages/feed.astro
+++ b/src/pages/feed.astro
@@ -1,0 +1,11 @@
+---
+import PageLayout from "@layouts/PageLayout.astro";
+import Feed from "@components/Feed.astro"
+
+const description = "A feed of all content on seanmcp.com in reverse chronological order."
+---
+
+<PageLayout title="Feed" description={description}>
+    <p>{description}</p>
+    <Feed />
+</PageLayout>

--- a/src/pages/gardens/[garden].astro
+++ b/src/pages/gardens/[garden].astro
@@ -20,10 +20,16 @@ const {
 } = entry;
 ---
 
-<PageLayout title={title} description={description} withoutH1>
+<PageLayout
+  {...entry.data}
+  title={title}
+  description={description}
+  showBreadcrumbs
+  withoutH1
+>
   <h1><GardenTitle title={title} state={getGardenState(entry)} /></h1>
   <GardenDetails tendedDates={tendedDates} />
-  <hr />
+  <br />
   <Content />
   <hr />
   <ContentFooter title={title} />

--- a/src/pages/gardens/[garden].astro
+++ b/src/pages/gardens/[garden].astro
@@ -1,0 +1,30 @@
+---
+import ContentFooter from "@components/ContentFooter.astro";
+import GardenDetails from "@components/GardenDetails.astro";
+import GardenTitle from "@components/GardenTitle.astro";
+import PageLayout from "@layouts/PageLayout.astro";
+import { getGardenState, getGardens } from "src/utils";
+
+export async function getStaticPaths() {
+  const gardens = await getGardens();
+  return gardens.map((entry) => ({
+    params: { garden: entry.slug },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+const { data } = entry;
+
+const title  = `${data.title} Garden`
+---
+
+<PageLayout title={title} description={data.description} withoutH1>
+    <h1><GardenTitle title={title} state={getGardenState(entry)}/></h1>
+    <GardenDetails tendedDates={data.tendedDates} />
+    <hr />
+    <Content />
+    <hr />
+    <ContentFooter title={title} />
+</PageLayout>

--- a/src/pages/gardens/[garden].astro
+++ b/src/pages/gardens/[garden].astro
@@ -15,16 +15,16 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await entry.render();
-const { data } = entry;
-
-const title  = `${data.title} Garden`
+const {
+  data: { description, tendedDates, title },
+} = entry;
 ---
 
-<PageLayout title={title} description={data.description} withoutH1>
-    <h1><GardenTitle title={title} state={getGardenState(entry)}/></h1>
-    <GardenDetails tendedDates={data.tendedDates} />
-    <hr />
-    <Content />
-    <hr />
-    <ContentFooter title={title} />
+<PageLayout title={title} description={description} withoutH1>
+  <h1><GardenTitle title={title} state={getGardenState(entry)} /></h1>
+  <GardenDetails tendedDates={tendedDates} />
+  <hr />
+  <Content />
+  <hr />
+  <ContentFooter title={title} />
 </PageLayout>

--- a/src/pages/gardens/index.astro
+++ b/src/pages/gardens/index.astro
@@ -43,8 +43,9 @@ gardens.forEach((garden) => {
   </p>
   {
     fresh.map((garden) => (
-      <article>
+      <article class="stack(xs)">
         <a href={`/gardens/${garden.slug}`}>{garden.data.title}</a>
+        <p>{garden.data.description}</p>
         <GardenDetails tendedDates={garden.data.tendedDates} />
       </article>
     ))
@@ -58,8 +59,9 @@ gardens.forEach((garden) => {
   </p>
   {
     wild.map((garden) => (
-      <article>
+      <article class="stack(xs)">
         <a href={`/gardens/${garden.slug}`}>{garden.data.title}</a>
+        <p>{garden.data.description}</p>
         <GardenDetails tendedDates={garden.data.tendedDates} />
       </article>
     ))
@@ -70,5 +72,9 @@ gardens.forEach((garden) => {
   cite {
     display: block;
     margin-block-start: var(--space-xs);
+  }
+
+  article a {
+    font-weight: bold;
   }
 </style>

--- a/src/pages/gardens/index.astro
+++ b/src/pages/gardens/index.astro
@@ -1,0 +1,79 @@
+---
+import GardenDetails from "@components/GardenDetails.astro";
+import GardenTitle from "@components/GardenTitle.astro";
+import PageLayout from "@layouts/PageLayout.astro";
+import { getGardenState, getGardens } from "src/utils";
+
+const gardens = await getGardens();
+
+const fresh = [];
+const wild = [];
+
+gardens.forEach((garden) => {
+  switch (getGardenState(garden)) {
+    case "FRESH": {
+      fresh.push(garden);
+      break;
+    }
+    case "WILD": {
+      wild.push(garden);
+      break;
+    }
+  }
+});
+---
+
+<PageLayout title="Gardens">
+  <blockquote>
+    A garden is a collection of evolving ideas that aren't strictly organised by
+    their publication date. They're inherently exploratory – notes are linked
+    through contextual associations. They aren't refined or complete - notes are
+    published as half-finished thoughts that will grow and evolve over time.
+    They're less rigid, less performative, and less perfect <cite
+      >– <a href="https://maggieappleton.com/garden-history">Maggie Appleton</a
+      ></cite
+    >
+  </blockquote>
+  <h2>
+    <GardenTitle title="Fresh" state="FRESH" />
+  </h2>
+  <p>
+    Gardens that have been tended in the previous year. They could be new or
+    well cared for.
+  </p>
+  {
+    fresh.map((garden) => (
+      <article>
+        <a href={`/gardens/${garden.slug}`}>{garden.data.title}</a>
+        <GardenDetails tendedDates={garden.data.tendedDates} />
+      </article>
+    ))
+  }
+  <h2>
+    <GardenTitle title="Wild" state="WILD" />
+  </h2>
+  <p>
+    Gardens that were last tended mover a year ago. They could be out of date or
+    just vintage.
+  </p>
+  {
+    wild.map((garden) => (
+      <article>
+        <a href={`/gardens/${garden.slug}`}>{garden.data.title}</a>
+        <GardenDetails tendedDates={garden.data.tendedDates} />
+      </article>
+    ))
+  }
+</PageLayout>
+
+<style>
+  cite {
+    display: block;
+    margin-block-start: var(--space-xs);
+  }
+
+  svg {
+    height: 1em;
+    width: 1em;
+  }
+</style>

--- a/src/pages/gardens/index.astro
+++ b/src/pages/gardens/index.astro
@@ -71,9 +71,4 @@ gardens.forEach((garden) => {
     display: block;
     margin-block-start: var(--space-xs);
   }
-
-  svg {
-    height: 1em;
-    width: 1em;
-  }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import ActivityGraph from "@components/ActivityGraph.astro";
-import ArticleList from "@components/ArticleList.astro";
-import NoteList from "@components/NoteList.astro";
+import Feed from "@components/Feed.astro";
 import PageLayout from "@layouts/PageLayout.astro";
 ---
 
@@ -31,17 +30,9 @@ import PageLayout from "@layouts/PageLayout.astro";
     <a href="/faith">Jesus Christ</a>.
   </p>
 
-  <h2>Recent articles</h2>
+  <h2>Feed</h2>
 
-  <ArticleList count={3} />
-
-  <p class="right()"><a href="/articles">Read more articles</a></p>
-
-  <h2>Latest note</h2>
-
-  <NoteList count={1} headingLevel={3} />
-
-  <p class="right()"><a href="/notes">Read more notes</a></p>
+  <Feed count={10}/>
 
   <h2>Activity</h2>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -283,6 +283,10 @@ li ul {
   gap: 0;
 }
 
+.line\(xs\) {
+  gap: var(--space-xs);
+}
+
 .hidden\(\) {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,9 +44,14 @@
   --github-dark-blue: hsl(206, 96%, 68%);
   --github-dark-purple: hsl(271, 92%, 80%);
 
+  --github-light-green: hsl(137, 63%, 33%);
   --github-light-blue: hsl(213, 94%, 35%);
   --github-light-purple: hsl(261, 69%, 59%);
   --github-light-black: hsl(213, 13%, 16%);
+
+  --green: var(--github-light-green);
+  --blue: var(--github-light-blue);
+  --purple: var(--github-light-purple);
 
   --dark-hs: 211, 21%;
   --dark: hsla(var(--dark-hs), 10%);
@@ -84,6 +89,10 @@ body {
 }
 
 html[data-theme="dark"] {
+  --green: var(--github-dark-green);
+  --blue: var(--github-dark-blue);
+  --purple: var(--github-dark-purple);
+
   --primary: var(--github-dark-purple);
   --accent: var(--github-dark-blue);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,6 +89,9 @@ export function getGardenState(garden: CollectionEntry<"gardens">) {
 
 export async function getGardens() {
   const gardens = await getCollection("gardens");
+  gardens.sort((a, b) =>
+    a.data.tendedDates[0] > b.data.tendedDates[0] ? -1 : 1
+  );
   return gardens;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,6 +80,18 @@ export async function getArticles(options?: {
     .slice(0, count);
 }
 
+export function getGardenState(garden: CollectionEntry<"gardens">) {
+  const lastYear = new Date();
+  lastYear.setFullYear(lastYear.getFullYear() - 1);
+
+  return garden.data.tendedDates[0] > lastYear ? "FRESH" : "WILD";
+}
+
+export async function getGardens() {
+  const gardens = await getCollection("gardens");
+  return gardens;
+}
+
 export async function getNotes(count?: number) {
   const notes = await getCollection("notes");
   return notes.sort(sortByPubDate).slice(0, count);


### PR DESCRIPTION
This PR adds a concept of garden content. These will be evergreen pages to build knowledge and resources that don't fit into the "article" mold.

**Todo**:
- [x] Migrate garden articles: Leave them in place, but move content and add a note with new URL
- [x] Add RSS feed: Three options a) a stand-alone RSS feed, b) integrate gardens in the article RSS, **c) or skip this entirely**.
- [x] Add section to home page
- [x] Add gardens to ActivityGraph
- [x] Add gardens to command palette